### PR TITLE
Use example rows from multiple example tables

### DIFF
--- a/lib/team_city_formatter/formatter.rb
+++ b/lib/team_city_formatter/formatter.rb
@@ -103,7 +103,7 @@ module TeamCityFormatter
     end
 
     def before_scenario_outline(cuke_scenario_outline)
-      cuke_example_rows = cuke_scenario_outline.examples_tables.map {|table| table.example_rows}.flatten
+      cuke_example_rows = cuke_scenario_outline.examples_tables.map(&:example_rows).flatten
       @scenario_outline = ScenarioOutline.new.tap do |x|
         x.name = "#{cuke_scenario_outline.keyword}: #{cuke_scenario_outline.name}"
         x.example_column_names = cuke_example_rows.first.send(:data).keys

--- a/lib/team_city_formatter/formatter.rb
+++ b/lib/team_city_formatter/formatter.rb
@@ -103,7 +103,7 @@ module TeamCityFormatter
     end
 
     def before_scenario_outline(cuke_scenario_outline)
-      cuke_example_rows = cuke_scenario_outline.examples_tables.first.example_rows
+      cuke_example_rows = cuke_scenario_outline.examples_tables.map {|table| table.example_rows}.flatten
       @scenario_outline = ScenarioOutline.new.tap do |x|
         x.name = "#{cuke_scenario_outline.keyword}: #{cuke_scenario_outline.name}"
         x.example_column_names = cuke_example_rows.first.send(:data).keys


### PR DESCRIPTION
Fixes a crash with having multiple example tables where it would only process the first example table